### PR TITLE
Recognize all Claude model ids in encode_prompt

### DIFF
--- a/agent_components.py
+++ b/agent_components.py
@@ -36,7 +36,7 @@ def random_string(length):
 def encode_prompt(model_id: str, conversation: list):
     ret_messages = []
 
-    if model_id.startswith('anthropic.claude-3') or model_id.startswith('apac.anthropic.claude-3'):
+    if 'anthropic.claude' in model_id:
         for message in conversation:
             if message['role'] == 'system':
                 message['role'] = 'user'


### PR DESCRIPTION
## Problem

`encode_prompt()` only builds the Bedrock Messages payload when the model id starts with `anthropic.claude-3` or `apac.anthropic.claude-3`:

```python
if model_id.startswith('anthropic.claude-3') or model_id.startswith('apac.anthropic.claude-3'):
```

Claude 4.5 inference-profile ids match neither — different region prefix (`jp.`) and version (`4-5`, not `3`):

- `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`
- `jp.anthropic.claude-haiku-4-5-20251001-v1:0`

So `encode_prompt` returns an empty `messages` list and every `InvokeModel` call fails with `messages: at least one message is required`. With the comma-separated fallback from this branch, both candidates fail and the agent dies:

```
[bedrock-agent] all models failed: [
 ('jp.anthropic.claude-sonnet-4-5-20250929-v1:0', "ValidationException(... at least one message is required)"),
 ('jp.anthropic.claude-haiku-4-5-20251001-v1:0', "ValidationException(... at least one message is required)")]
```

This breaks any downstream agent that adopts the 4.5 model ids.

## Fix

Match any `anthropic.claude` model id instead, covering all region prefixes (jp./apac./us./eu./none) and versions. The Messages content-block format (and the `system → user` rewrite for mid-conversation messages) is identical across Claude 3+ models.

```diff
-    if model_id.startswith('anthropic.claude-3') or model_id.startswith('apac.anthropic.claude-3'):
+    if 'anthropic.claude' in model_id:
```

Verified `encode_prompt` now returns non-empty messages for both 4.5 ids and the legacy `anthropic.claude-3-5` / `apac.anthropic.claude-3-5` ids (regression-safe), while non-Claude ids (e.g. Titan) still return empty.

Based on `bedrock-model-fallback` (PR #10) since that branch introduced the model ids that expose this.
